### PR TITLE
Add support for cron action (to update a scheduled task)

### DIFF
--- a/README.md
+++ b/README.md
@@ -201,6 +201,33 @@ with:
   timeout: -1
 ```
 
+### Deploy a Scheduled Task (Cron) Update
+
+The `cron` action deploys a new task definition to a Scheduled Task rule. The `target` should be a task definition
+family name, and the `rule` option must specify the CloudWatch Events rule name.
+
+```yml
+uses: donaldpiret/ecs-deploy@master
+with:
+  action: cron
+  cluster: theClusterName
+  target: taskName
+  rule: ruleName
+  image: application my-app:1.2.3
+```
+
+The following options work the same with `cron` as with `deploy` to update the task definition:
+
+- `image`
+- `tag`
+- `env_vars`
+- `exclusive_env`
+- `task_role`
+- `command`
+- `no_deregister`
+- `rollback`
+- `timeout`
+
 ### Scaling
 
 #### Scale a service

--- a/README.md
+++ b/README.md
@@ -226,7 +226,6 @@ The following options work the same with `cron` as with `deploy` to update the t
 - `command`
 - `no_deregister`
 - `rollback`
-- `timeout`
 
 ### Scaling
 

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ with:
   target: theServiceName
 ```
 
-### Deploy a new tag
+#### Deploy a new tag
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -26,7 +26,7 @@ with:
   tag: 1.2.3
  ```
 
-### Deploy a new image
+#### Deploy a new image
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -36,7 +36,7 @@ with:
   image: webserver nginx:1.11.8
  ```
 
-### Deploy several new images
+#### Deploy several new images
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -46,7 +46,7 @@ with:
   image: webserver nginx:1.11.8, application my-app:1.2.3
  ```
 
-### Deploy a custom task definition
+#### Deploy a custom task definition
 
 With a fully-qualified ARN
 
@@ -78,7 +78,7 @@ with:
   task: my-task
  ```
 
-### Set an environment variable
+#### Set an environment variable
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -88,7 +88,7 @@ with:
   env_vars: containerName SOME_VARIABLE SOME_VALUE
  ```
 
-### Adjust multiple environment variables
+#### Adjust multiple environment variables
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -98,7 +98,7 @@ with:
   env_vars: containerName SOME_VARIABLE SOME_VALUE, containerName OTHER_VARIABLE OTHER_VALUE, appContainerName APP_VARIABLE APP_VALUE
  ```
 
-### Set environment variables exclusively, remove all other pre-existing environment variables
+#### Set environment variables exclusively, remove all other pre-existing environment variables
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -109,7 +109,7 @@ with:
   exclusive_env: true
  ```
 
-### Set a secret environment variable from the AWS Parameter Store or Secrets Manager
+#### Set a secret environment variable from the AWS Parameter Store or Secrets Manager
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -119,7 +119,7 @@ with:
   secrets: containerName SOME_SECRET arn:aws:ssm:<aws region>:<aws account id>:parameter/KEY_OF_SECRET_IN_PARAMETER_STORE
  ```
 
-### Set secrets exclusively, remove all other pre-existing secret environment variables
+#### Set secrets exclusively, remove all other pre-existing secret environment variables
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -130,7 +130,7 @@ with:
   exclusive_secrets: true 
 ```
 
-### Modify a command
+#### Modify a command
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -140,7 +140,7 @@ with:
   command: containerName "nginx -c /etc/nginx/nginx.conf"
 ```
 
-### Set a task role
+#### Set a task role
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -150,7 +150,7 @@ with:
   task_role: arn:aws:iam::123456789012:role/MySpecialEcsTaskRole
 ```
 
-### Ignore capacity issues
+#### Ignore capacity issues
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -160,7 +160,7 @@ with:
   ignore_warnings: true
 ```
 
-### Disable task defintion deregistration
+#### Disable task definition deregistration
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -170,7 +170,7 @@ with:
   no_deregister: true
 ```
 
-### Rollback on failure
+#### Rollback on failure
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -180,7 +180,7 @@ with:
   rollback: true
 ```
 
-### Deployment timeout
+#### Deployment timeout
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -201,9 +201,9 @@ with:
   timeout: -1
 ```
 
-## Scaling
+### Scaling
 
-### Scale a service
+#### Scale a service
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -214,9 +214,9 @@ with:
   scale_value: 4
 ```
 
-## Running a Task
+### Running a Task
 
-### Run a one-off task
+#### Run a one-off task
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -237,7 +237,7 @@ with:
   env_vars: containerName SOME_VARIABLE SOME_VALUE, containerName OTHER_VARIABLE OTHER_VALUE, appContainerName APP_VARIABLE APP_VALUE
  ```
 
-### Run a task with a custom command
+#### Run a task with a custom command
 
 ```yml
 uses: donaldpiret/ecs-deploy@master
@@ -248,7 +248,7 @@ with:
   command: my-container "python some-script.py param1 param2"
 ```
 
-### Run a task in a Fargate Cluster
+#### Run a task in a Fargate Cluster
 
 TODO
 

--- a/action.yml
+++ b/action.yml
@@ -15,10 +15,10 @@ inputs:
     description: 'Service or task name to perform this action on'
     required: true
   tag:
-    description: 'Applicable to the deploy action. Changes the tag of all images in all containers in the task definition to the tag given'
+    description: 'Applicable to the deploy and cron actions. Changes the tag of all images in all containers in the task definition to the tag given'
     required: false
   image:
-    description: 'Applicable to the deploy action. Updates the image of a specific container. Pass the value as "[container-name] [image-name]:[image-tag]". You can pass multiple values as comma-separated'
+    description: 'Applicable to the deploy and cron actions. Updates the image of a specific container. Pass the value as "[container-name] [image-name]:[image-tag]". You can pass multiple values as comma-separated'
     required: false
   task:
     description: 'Applicable to the deploy action. Updates the target service with a new task definition, which can either be an ARN, a family name with revision, or just a family name (you will get the most recent revision)'

--- a/action.yml
+++ b/action.yml
@@ -23,6 +23,9 @@ inputs:
   task:
     description: 'Applicable to the deploy action. Updates the target service with a new task definition, which can either be an ARN, a family name with revision, or just a family name (you will get the most recent revision)'
     required: false
+  rule:
+    description: 'Applicable to the cron action. Updates the scheduled task rule with a new task definition'
+    required: false
   env_vars:
     description: 'Set one or more environment variables. The syntax is "[container] [ENV_VAR_NAME] [ENV_VAR_VALUE]". You can set multiple env vars by comma-separating them as "[container] [ENV_VAR_NAME] [ENV_VAR_VALUE], [container] [ANOTHER_ENV_VAR_NAME] [ANOTHER_ENV_VAR_VALUE]"'
     required: false

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -109,11 +109,13 @@ append_deploy_vars() {
     CMD="${CMD} --no-deregister"
   fi
 
-    if [ "$INPUT_ROLLBACK" = "true" ]; then
+  if [ "$INPUT_ROLLBACK" = "true" ]; then
     CMD="${CMD} --rollback"
   fi
 
-  CMD="${CMD} --timeout ${TIMEOUT}"
+  if [ "$INPUT_ACTION" != "cron" ]; then
+    CMD="${CMD} --timeout ${TIMEOUT}"
+  fi
 }
 
 case $INPUT_ACTION in

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -29,6 +29,26 @@ deploy_action() {
   fi
 }
 
+## Cron function
+cron_action() {
+  [ -z "$INPUT_RULE" ] && (echo "Missing rule" && exit 1)
+
+  CMD="${CMD} ${INPUT_RULE}"
+
+  if [ -n "$INPUT_TAG" ]; then # Deploying a specific tag
+    CMD="${CMD} -t ${INPUT_TAG}"
+  elif [ -n "$INPUT_IMAGE" ]; then # Deploying one or more images
+    rest=$INPUT_IMAGE
+    while [ -n "$rest" ] ; do
+      str=${rest%%,*}  # Everything up to the first ','
+      # Trim up to the first ',' -- and handle final case, too.
+      [ "$rest" = "${rest/,/}" ] && rest= || rest=${rest#*,}
+
+      CMD="${CMD} -i $str"
+    done
+  fi
+}
+
 ## Scale function
 scale_action() {
   [ -z "$INPUT_SCALE_VALUE" ] && (echo "Missing scale value" && exit 1)
@@ -100,6 +120,12 @@ case $INPUT_ACTION in
 deploy) # Deployment action
   echo "Performing deploy"
   deploy_action
+  append_common_vars
+  append_deploy_vars
+  ;;
+cron) # Cron action
+  echo "Performing cron"
+  cron_action
   append_common_vars
   append_deploy_vars
   ;;


### PR DESCRIPTION
ecs-deploy supports `cron` action since https://github.com/fabfuel/ecs-deploy/pull/104 - which allows to deploy task definition updates to a Scheduled Task Rule instead of a Service.

This PR adds support for the `cron` action here.

Usage looks like:

```yml
uses: donaldpiret/ecs-deploy@master
with:
  action: cron
  cluster: theClusterName
  target: taskName
  rule: ruleName
  image: application my-app:1.2.3
```

It accepts most of the same arguments as the `deploy` action, as you can check here:
https://github.com/fabfuel/ecs-deploy/blob/b091b6b83f209f3456f81194bf09aacf7db0820d/ecs_deploy/cli.py#L129